### PR TITLE
Restrict registration endpoint to USER role

### DIFF
--- a/src/main/java/com/gym/gym_management/authentication/AuthenticationController.java
+++ b/src/main/java/com/gym/gym_management/authentication/AuthenticationController.java
@@ -30,7 +30,7 @@ public class AuthenticationController {
         this.authenticationManager = authenticationManager;
     }
 
-
+    @PreAuthorize("hasRole('USER')")
     @PostMapping("/register")
     public ResponseEntity<AuthenticationResponse> register (
             @RequestBody RegisterRequest request) {

--- a/src/main/java/com/gym/gym_management/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/gym/gym_management/configuration/SecurityConfiguration.java
@@ -35,8 +35,9 @@ public class SecurityConfiguration {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(
                         auth -> auth
-                                // Permitir acceso público solo para login y rutas de documentación
-                                .requestMatchers("/auth/**").permitAll()
+                                // Permitir acceso público solo para login; registrar requiere rol USER
+                                .requestMatchers(HttpMethod.POST, "/auth/login").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/auth/register").hasRole("USER")
                                 .anyRequest().authenticated()
 
                 )


### PR DESCRIPTION
## Summary
- Limit public access to only `/auth/login`
- Require USER role to access registration

## Testing
- ❌ `mvn test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689df62a4708832da6a975453f2bec81